### PR TITLE
CASMHMS-5451 

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -128,6 +128,9 @@ jobs:
       image-tag: ${{ steps.image-meta.outputs.tag }}
       image-repository: ${{ steps.image-meta.outputs.repository }}
       all-image-tags: ${{ steps.meta.outputs.tags }}
+    permissions: # Required for google-github-actions/auth
+      contents: 'read'
+      id-token: 'write'
     steps:
     #
     # Setup build environment

--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -256,7 +256,7 @@ jobs:
         done
 
     - name: Sign an image in artifactory
-      uses: Cray-HPE/.github/actions/csm-sign-image@v2.0-csm-sign-image
+      uses: Cray-HPE/.github/actions/csm-sign-image@v2-csm-sign-image
       with:
         cosign-gcp-project-id: ${{ secrets.cosign-gcp-project-id }}
         cosign-gcp-sa-key: ${{ secrets.cosign-gcp-sa-key }}
@@ -268,7 +268,7 @@ jobs:
         image: ${{ steps.image-meta.outputs.image }}
 
     - name: Generate, Attach, and Sign container image SBOM
-      uses: Cray-HPE/.github/actions/csm-generate-attach-sign-sbom@v1.0-csm-generate-attach-sign-sbom
+      uses: Cray-HPE/.github/actions/csm-generate-attach-sign-sbom@v1-csm-generate-attach-sign-sbom
       id: sbom
       with:
         cosign-gcp-project-id: ${{ secrets.cosign-gcp-project-id }}


### PR DESCRIPTION
Pull in new versions of the csm-generate-attach-sign-sbom and csm-sign-image actions to fix: https://github.com/Cray-HPE/hms-firmware-action/runs/5644996519?check_suite_focus=true#step:16:278

- [x] Merge once the following error has been resolved https://github.com/Cray-HPE/hms-firmware-action/runs/5645965572?check_suite_focus=true

```
Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
```