### PR TITLE
CASMHMS-6449: Temporarily change snyk severity from high to critical in HMS image builds

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -1,6 +1,6 @@
 # MIT License
 
-# (C) Copyright 2022,2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022,2024-2025 Hewlett Packard Enterprise Development LP
 
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -65,7 +65,7 @@ on:
           Only report vulnerabilities of provided level or higher.
           Choose from: low, medium, high, or critical
         type: string
-        default: high
+        default: critical
         required: false
 
       # TODO It doesn't look like continue-on-error can be templated


### PR DESCRIPTION
## Summary and Scope

Temporarily increase the snyk-severity in our HMS builds from high to critical so that the new Alpine 3.21.3 CVE documented in CASMHMS-6449 doesn't prevent PRs from merging due to failed builds due to the failed Snyk scan.  Once Alpine 3.21.4 is released, we can back this change out.

## Issues and Related PRs

* Resolves [CASMHMS-6449](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6449)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

