### PR TITLE
CASMHMS-6449: Continue on error and restore default severity for snyk…

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -65,7 +65,7 @@ on:
           Only report vulnerabilities of provided level or higher.
           Choose from: low, medium, high, or critical
         type: string
-        default: critical
+        default: high
         required: false
 
       # TODO It doesn't look like continue-on-error can be templated
@@ -369,6 +369,7 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         args: "snyk test --severity-threshold=${{ inputs.snyk-severity }} --skip-unresolved=true --docker ${{ steps.image-meta.outputs.image }}"
+      continue-on-error: true
 
     # TODO need a policy on how to use Trivy results
     - name: Run Trivy vulnerability scanner 


### PR DESCRIPTION
## Summary and Scope

Restore default severity threshold to "high".

Due to new unresolved critical CVEs upstream in Alpine 3.21.4, add continue-on-error for snyk scans so that builds do not fail.  We will back this change out after Alpine 3.21.5 is released.

Note that all of the check-failures showing up in the PR diff, and failed actionlint scan, will be resolved in the future by [CASMHMS-6450](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6450)

## Issues and Related PRs

* Resolves [CASMHMS-6449](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6449)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable